### PR TITLE
Proposal: Respect the gamerule announceAdvancement

### DIFF
--- a/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/mixin/AdvancementMixin.java
+++ b/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/mixin/AdvancementMixin.java
@@ -13,6 +13,7 @@ import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.server.PlayerAdvancements;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.GameRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -38,6 +39,9 @@ public class AdvancementMixin {
         final Advancement advancement = advancementEntry.value();
         if (LinkManager.isPlayerLinked(player.getUUID()) && LinkManager.getLink(null, player.getUUID()).settings.hideFromDiscord)
             return;
+        
+        if (!player.serverLevel().getGameRules().getBoolean(GameRules.RULE_ANNOUNCE_ADVANCEMENTS)) return;
+        
         if (advancement.display().isPresent() && advancement.display().get().shouldAnnounceChat()) {
 
             if (!Localization.instance().advancementMessage.isBlank()) {


### PR DESCRIPTION
Proposing this check to be added as noticed that when using https://modrinth.com/datapack/blazeandcaves-advancements-pack as it has config to set different tiers of Advancements to display or not- it does not actually set the advancements themselves to not display but rather toggles and toggles GameRules.RULE_ANNOUNCE_ADVANCEMENTS to do this dynamically.  

Just a small change, if you think it may be beneficial to only do this under a config toggle then let me know.

The result in this is lots of Advancements (basic tasks and alike) that have been set to not announce do not announce in the gamechat, but they do all get announced in discord.  

###### having build issues, and unable to test with the latest 1.21.4 release as cannot find in VCS, if there are particular Gradle tasks for testing that I should run please feel free to inform me :)