### PR TITLE
Add %texture_hash% for avatar URLs

### DIFF
--- a/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/DiscordIntegrationMod.java
+++ b/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/DiscordIntegrationMod.java
@@ -5,6 +5,7 @@ import dcshadow.net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
 import de.erdbeerbaerlp.dcintegration.architectury.api.ArchitecturyDiscordEventHandler;
 import de.erdbeerbaerlp.dcintegration.architectury.command.McCommandDiscord;
 import de.erdbeerbaerlp.dcintegration.architectury.metrics.Metrics;
+import de.erdbeerbaerlp.dcintegration.architectury.util.PlayerTextureUtils;
 import de.erdbeerbaerlp.dcintegration.architectury.util.SerializeComponentUtils;
 import de.erdbeerbaerlp.dcintegration.architectury.util.MessageUtilsImpl;
 import de.erdbeerbaerlp.dcintegration.architectury.util.ServerInterface;
@@ -305,12 +306,13 @@ public final class DiscordIntegrationMod {
             text = MessageUtils.escapeMarkdown(text);
             if (!Localization.instance().discordChatMessage.isBlank())
                 if (Configuration.instance().embedMode.enabled && Configuration.instance().embedMode.chatMessages.asEmbed) {
-                    final String avatarURL = INSTANCE.getSkinURL().replace("%uuid%", player.getUUID().toString()).replace("%uuid_dashless%", player.getUUID().toString().replace("-", "")).replace("%name%", player.getName().getString()).replace("%randomUUID%", UUID.randomUUID().toString());
+                    final String avatarURL = PlayerTextureUtils.getAvatarUrl(player);
                     if (!Configuration.instance().embedMode.chatMessages.customJSON.isBlank()) {
                         final EmbedBuilder b = Configuration.instance().embedMode.chatMessages.toEmbedJson(Configuration.instance().embedMode.chatMessages.customJSON
                                 .replace("%uuid%", player.getUUID().toString())
                                 .replace("%uuid_dashless%", player.getUUID().toString().replace("-", ""))
                                 .replace("%name%", MessageUtilsImpl.formatPlayerName(player))
+                                .replace("%texture_hash%", PlayerTextureUtils.getPlayerTextureHash(player))
                                 .replace("%randomUUID%", UUID.randomUUID().toString())
                                 .replace("%avatarURL%", avatarURL)
                                 .replace("%msg%", text)

--- a/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/mixin/AdvancementMixin.java
+++ b/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/mixin/AdvancementMixin.java
@@ -1,6 +1,7 @@
 package de.erdbeerbaerlp.dcintegration.architectury.mixin;
 
 import de.erdbeerbaerlp.dcintegration.architectury.util.MessageUtilsImpl;
+import de.erdbeerbaerlp.dcintegration.architectury.util.PlayerTextureUtils;
 import de.erdbeerbaerlp.dcintegration.common.DiscordIntegration;
 import de.erdbeerbaerlp.dcintegration.common.storage.Configuration;
 import de.erdbeerbaerlp.dcintegration.common.storage.Localization;
@@ -42,12 +43,13 @@ public class AdvancementMixin {
 
             if (!Localization.instance().advancementMessage.isBlank()) {
                 if (Configuration.instance().embedMode.enabled && Configuration.instance().embedMode.advancementMessage.asEmbed) {
-                    final String avatarURL = INSTANCE.getSkinURL().replace("%uuid%", player.getUUID().toString()).replace("%uuid_dashless%", player.getUUID().toString().replace("-", "")).replace("%name%", player.getName().getString()).replace("%randomUUID%", UUID.randomUUID().toString());
+                    final String avatarURL = PlayerTextureUtils.getAvatarUrl(player);
                     if (!Configuration.instance().embedMode.advancementMessage.customJSON.isBlank()) {
                         final EmbedBuilder b = Configuration.instance().embedMode.advancementMessage.toEmbedJson(Configuration.instance().embedMode.advancementMessage.customJSON
                                 .replace("%uuid%", player.getUUID().toString())
                                 .replace("%uuid_dashless%", player.getUUID().toString().replace("-", ""))
                                 .replace("%name%", MessageUtilsImpl.formatPlayerName(player))
+                                .replace("%texture_hash%", PlayerTextureUtils.getPlayerTextureHash(player))
                                 .replace("%randomUUID%", UUID.randomUUID().toString())
                                 .replace("%avatarURL%", avatarURL)
                                 .replace("%advName%", ChatFormatting.stripFormatting(advancement.display().get().getTitle().getString()))

--- a/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/mixin/NetworkHandlerMixin.java
+++ b/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/mixin/NetworkHandlerMixin.java
@@ -3,6 +3,7 @@ package de.erdbeerbaerlp.dcintegration.architectury.mixin;
 
 import de.erdbeerbaerlp.dcintegration.architectury.DiscordIntegrationMod;
 import de.erdbeerbaerlp.dcintegration.architectury.util.MessageUtilsImpl;
+import de.erdbeerbaerlp.dcintegration.architectury.util.PlayerTextureUtils;
 import de.erdbeerbaerlp.dcintegration.common.DiscordIntegration;
 import de.erdbeerbaerlp.dcintegration.common.storage.Configuration;
 import de.erdbeerbaerlp.dcintegration.common.storage.Localization;
@@ -43,7 +44,7 @@ public class NetworkHandlerMixin {
         if (reason.equals(Component.translatable("disconnect.timeout")))
             DiscordIntegrationMod.timeouts.add(this.player.getUUID());
         INSTANCE.callEventC((a)->a.onPlayerLeave(player.getUUID()));
-        final String avatarURL = INSTANCE.getSkinURL().replace("%uuid%", player.getUUID().toString()).replace("%uuid_dashless%", player.getUUID().toString().replace("-", "")).replace("%name%", player.getName().getString()).replace("%randomUUID%", UUID.randomUUID().toString());
+        final String avatarURL = PlayerTextureUtils.getAvatarUrl(player);
         if (DiscordIntegration.INSTANCE != null && !DiscordIntegrationMod.timeouts.contains(player.getUUID())) {
             if (!Localization.instance().playerLeave.isBlank()) {
                 if (Configuration.instance().embedMode.enabled && Configuration.instance().embedMode.playerLeaveMessages.asEmbed) {
@@ -52,6 +53,7 @@ public class NetworkHandlerMixin {
                                 .replace("%uuid%", player.getUUID().toString())
                                 .replace("%uuid_dashless%", player.getUUID().toString().replace("-", ""))
                                 .replace("%name%", MessageUtilsImpl.formatPlayerName(player))
+                                .replace("%texture_hash%", PlayerTextureUtils.getPlayerTextureHash(player))
                                 .replace("%randomUUID%", UUID.randomUUID().toString())
                                 .replace("%avatarURL%", avatarURL)
                                 .replace("%playerColor%", "" + TextColors.generateFromUUID(player.getUUID()).getRGB())

--- a/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/mixin/PlayerManagerMixin.java
+++ b/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/mixin/PlayerManagerMixin.java
@@ -3,6 +3,7 @@ package de.erdbeerbaerlp.dcintegration.architectury.mixin;
 import dcshadow.net.kyori.adventure.text.Component;
 import dcshadow.net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import de.erdbeerbaerlp.dcintegration.architectury.util.MessageUtilsImpl;
+import de.erdbeerbaerlp.dcintegration.architectury.util.PlayerTextureUtils;
 import de.erdbeerbaerlp.dcintegration.architectury.util.SerializeComponentUtils;
 import de.erdbeerbaerlp.dcintegration.common.DiscordIntegration;
 import de.erdbeerbaerlp.dcintegration.common.WorkThread;
@@ -77,12 +78,13 @@ public class PlayerManagerMixin {
             LinkManager.checkGlobalAPI(p.getUUID());
             if (!Localization.instance().playerJoin.isBlank()) {
                 if (Configuration.instance().embedMode.enabled && Configuration.instance().embedMode.playerJoinMessage.asEmbed) {
-                    final String avatarURL = INSTANCE.getSkinURL().replace("%uuid%", p.getUUID().toString()).replace("%uuid_dashless%", p.getUUID().toString().replace("-", "")).replace("%name%", p.getName().getString()).replace("%randomUUID%", UUID.randomUUID().toString());
+                    final String avatarURL = PlayerTextureUtils.getAvatarUrl(p);
                     if (!Configuration.instance().embedMode.playerJoinMessage.customJSON.isBlank()) {
                         final EmbedBuilder b = Configuration.instance().embedMode.playerJoinMessage.toEmbedJson(Configuration.instance().embedMode.playerJoinMessage.customJSON
                                 .replace("%uuid%", p.getUUID().toString())
                                 .replace("%uuid_dashless%", p.getUUID().toString().replace("-", ""))
                                 .replace("%name%", MessageUtilsImpl.formatPlayerName(p))
+                                .replace("%texture_hash%", PlayerTextureUtils.getPlayerTextureHash(p))
                                 .replace("%randomUUID%", UUID.randomUUID().toString())
                                 .replace("%avatarURL%", avatarURL)
                                 .replace("%playerColor%", "" + TextColors.generateFromUUID(p.getUUID()).getRGB())

--- a/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/mixin/ServerPlayerMixin.java
+++ b/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/mixin/ServerPlayerMixin.java
@@ -1,6 +1,7 @@
 package de.erdbeerbaerlp.dcintegration.architectury.mixin;
 
 import de.erdbeerbaerlp.dcintegration.architectury.util.MessageUtilsImpl;
+import de.erdbeerbaerlp.dcintegration.architectury.util.PlayerTextureUtils;
 import de.erdbeerbaerlp.dcintegration.common.DiscordIntegration;
 import de.erdbeerbaerlp.dcintegration.common.storage.Configuration;
 import de.erdbeerbaerlp.dcintegration.common.storage.Localization;
@@ -35,12 +36,13 @@ public class ServerPlayerMixin {
             final MessageEmbed embed = MessageUtilsImpl.genItemStackEmbedIfAvailable(deathMessage, p.level());
             if (!Localization.instance().playerDeath.isBlank())
                 if (Configuration.instance().embedMode.enabled && Configuration.instance().embedMode.deathMessage.asEmbed) {
-                    final String avatarURL = INSTANCE.getSkinURL().replace("%uuid%", p.getUUID().toString()).replace("%uuid_dashless%", p.getUUID().toString().replace("-", "")).replace("%name%", p.getName().getString()).replace("%randomUUID%", UUID.randomUUID().toString());
+                    final String avatarURL = PlayerTextureUtils.getAvatarUrl(p);
                     if(!Configuration.instance().embedMode.deathMessage.customJSON.isBlank()){
                         final EmbedBuilder b = Configuration.instance().embedMode.deathMessage.toEmbedJson(Configuration.instance().embedMode.deathMessage.customJSON
                                 .replace("%uuid%", p.getUUID().toString())
                                 .replace("%uuid_dashless%", p.getUUID().toString().replace("-", ""))
                                 .replace("%name%", MessageUtilsImpl.formatPlayerName(p))
+                                .replace("%texture_hash%", PlayerTextureUtils.getPlayerTextureHash(p))
                                 .replace("%randomUUID%", UUID.randomUUID().toString())
                                 .replace("%avatarURL%", avatarURL)
                                 .replace("%deathMessage%", ChatFormatting.stripFormatting(deathMessage.getString()).replace(MessageUtilsImpl.formatPlayerName(p) + " ", ""))

--- a/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/util/PlayerTextureUtils.java
+++ b/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/util/PlayerTextureUtils.java
@@ -1,0 +1,37 @@
+package de.erdbeerbaerlp.dcintegration.architectury.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.mojang.authlib.properties.Property;
+import net.minecraft.world.entity.player.Player;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
+
+import static de.erdbeerbaerlp.dcintegration.common.DiscordIntegration.INSTANCE;
+import static de.erdbeerbaerlp.dcintegration.common.DiscordIntegration.LOGGER;
+
+public class PlayerTextureUtils {
+    static public String getPlayerTextureHash(Player player) {
+        try {
+            String textureData = player.getGameProfile().properties().get("textures").iterator().next().value();
+            textureData = new String(Base64.getDecoder().decode(textureData), StandardCharsets.UTF_8);
+            String url = (new Gson()).fromJson(textureData, JsonObject.class).getAsJsonObject("textures").getAsJsonObject("SKIN").get("url").getAsString();
+            // remove "http://textures.minecraft.net/texture/" but generically
+            return url.replaceAll(".*\\/", "");
+        }
+        catch (Exception e) {
+            return "null";
+        }
+    }
+
+    static public String getAvatarUrl(Player player) {
+        return INSTANCE.getSkinURL()
+                .replace("%uuid%", player.getUUID().toString())
+                .replace("%uuid_dashless%", player.getUUID().toString().replace("-", ""))
+                .replace("%name%", player.getName().getString())
+                .replace("%texture_hash%", getPlayerTextureHash(player))
+                .replace("%randomUUID%", UUID.randomUUID().toString());
+    }
+}

--- a/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/util/PlayerTextureUtils.java
+++ b/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/util/PlayerTextureUtils.java
@@ -2,7 +2,6 @@ package de.erdbeerbaerlp.dcintegration.architectury.util;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import com.mojang.authlib.properties.Property;
 import net.minecraft.world.entity.player.Player;
 
 import java.nio.charset.StandardCharsets;
@@ -10,7 +9,6 @@ import java.util.Base64;
 import java.util.UUID;
 
 import static de.erdbeerbaerlp.dcintegration.common.DiscordIntegration.INSTANCE;
-import static de.erdbeerbaerlp.dcintegration.common.DiscordIntegration.LOGGER;
 
 public class PlayerTextureUtils {
     static public String getPlayerTextureHash(Player player) {
@@ -19,7 +17,7 @@ public class PlayerTextureUtils {
             textureData = new String(Base64.getDecoder().decode(textureData), StandardCharsets.UTF_8);
             String url = (new Gson()).fromJson(textureData, JsonObject.class).getAsJsonObject("textures").getAsJsonObject("SKIN").get("url").getAsString();
             // remove "http://textures.minecraft.net/texture/" but generically
-            return url.replaceAll(".*\\/", "");
+            return url.replaceAll(".*/", "");
         }
         catch (Exception e) {
             return "null";


### PR DESCRIPTION
Adds `%texture_hash%` in avatar URLs, which can be used with dynamic skin changing tools (ex SkinRestorer) which are useful with offline servers. Also refactored how the avatar URL is made so it's not in 1000 different places.

Also see the PR in [DiscordIntegration-Core](https://github.com/knot126/DiscordIntegration-Core) which makes the skin API availability check work.

Sorry if anything here is bad, I'm not a good Java programmer. Also I'm not sure exactly how I should go about backporting this for the other versions so it's just 26.2 for now.