### PR TITLE
respect "discordChatMessage" string and fix webhook not using player name and avatar

### DIFF
--- a/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/DiscordIntegrationMod.java
+++ b/common/src/main/java/de/erdbeerbaerlp/dcintegration/architectury/DiscordIntegrationMod.java
@@ -326,7 +326,7 @@ public final class DiscordIntegrationMod {
                         DiscordIntegration.INSTANCE.sendMessage(new DiscordMessage(b.build()), INSTANCE.getChannel(Configuration.instance().advanced.chatOutputChannelID));
                     }
                 } else
-                    DiscordIntegration.INSTANCE.sendMessage(new DiscordMessage(embed, MessageUtilsImpl.formatPlayerName(player) + ": " + text, true), channel);
+                    DiscordIntegration.INSTANCE.sendMessage(MessageUtilsImpl.formatPlayerName(player), player.getUUID().toString(), new DiscordMessage(embed, Localization.instance().discordChatMessage.replace("%player%", MessageUtilsImpl.formatPlayerName(player)).replace("%msg%", text), true), channel);
 
             if (!Configuration.instance().compatibility.disableParsingMentionsIngame) {
                 final String editedJson = GsonComponentSerializer.gson().serialize(MessageUtils.mentionsToNames(comp, channel.getGuild()));


### PR DESCRIPTION
fixed issues caused by #37 improper implementation
before:
<img width="288" height="51" alt="image showing player message being sent with username Minecraft Server" src="https://github.com/user-attachments/assets/a6990f36-4e86-412b-a037-d425943da236" />
after:
<img width="215" height="67" alt="image showing player message sent correctly with username and avatar" src="https://github.com/user-attachments/assets/5b24cb47-1ef2-441e-a0ca-7e4fd077b0f5" />
<img width="390" height="60" alt="image showing template string working as intended" src="https://github.com/user-attachments/assets/e392bbab-1f23-4907-ac94-24de5443126c" />
